### PR TITLE
fix: Disable creation of keycloak-database secret if keycloak is disabled

### DIFF
--- a/charts/registry/templates/keycloak/database-credentials.yaml
+++ b/charts/registry/templates/keycloak/database-credentials.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.keycloak.postgresql.enabled }}
+{{ if and .Values.enableKeycloak (not .Values.keycloak.postgresql.enabled) }}
 ###############################################################
 # Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2023 Contributors to the Eclipse Foundation


### PR DESCRIPTION
This change disables the creation of the keycloak-database secret if keycloak is disabled at all